### PR TITLE
Specify auto-complete on password Input component to prevent warning 

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,13 +8,22 @@ const name = pkg.name
   .replace(/-\w/g, m => m[1].toUpperCase())
 
 export default {
-  input: 'src/index.js',
-  output: [
-    { file: pkg.module, 'format': 'es' },
-    { file: pkg.main, 'format': 'umd', name }
-  ],
-  plugins: [
-    svelte(),
-    resolve()
-  ]
-}
+	input: "src/index.js",
+	output: [
+		{
+			file: pkg.module,
+			sourcemap: true,
+			format: "es",
+		},
+		{
+			file: pkg.main,
+			sourcemap: true,
+			format: "umd",
+			name,
+		},
+	],
+	plugins: [
+		svelte(),
+		resolve()
+	],
+};

--- a/src/Input.svelte
+++ b/src/Input.svelte
@@ -24,7 +24,7 @@
     {:else if type == 'email'}
       <input type="email" {name} {placeholder} bind:value>
     {:else if type == 'password'}
-      <input type="password" {name} {placeholder} bind:value>
+      <input type="password" {name} {placeholder} autocomplete="on" bind:value>
     {/if}
   </div>
 </label>


### PR DESCRIPTION
"[DOM] Input elements should have autocomplete attributes (suggested: "current-password"): "

Google chrome now requires to specify it 
<input type="password" name="password" autocomplete="on">

Autocomplete lets web developers specify what permission the user agent has to provide automated assistance in filling out form field values, as well as guidance to the browser as to the type of information expected in the field. 

Thanks
