### PR TITLE
v0.1.2 - Updated Provider types to match documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
   "dependencies": {
     "svelte-feather-icons": "^3.3.0"
   },
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,11 @@
 import type { SvelteComponentTyped } from 'svelte'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
+export type Providers = 'azure' | 'bitbucket' | 'discord' | 'facebook' | 'github' | 'gitlab' | 'google'; 
+
 export interface AuthProps {
   supabaseClient: SupabaseClient
-  providers?: ('azure' | 'bitbucket' | 'facebook' | 'github' | 'gitlab' | 'google')[]
+  providers?: Providers[]
   view?: 'sign_in' | 'sign_up' | 'magic_link' | 'forgotten_password'
   classes?: string
   style?: string


### PR DESCRIPTION
Bumped to v0.1.2 
Fixes:
- `index.d.ts` is missing necessary provider values `discord`
- Created & Exported `Provider` type to avoid typescript error 2322:Type 'string[]' is not assignable to type '("github" | "google" | "azure" | "bitbucket" | "facebook" | "gitlab")[]'. (c.f. below)
<img width="869" alt="Screen Shot 2021-12-26 at 10 19 32 PM" src="https://user-images.githubusercontent.com/20456444/147430954-74d19c25-48ae-4a0c-ab0d-de9a18546fe0.png">

