### PR TITLE
Fixed fuzzy text in socials and login button

### DIFF
--- a/src/Button.svelte
+++ b/src/Button.svelte
@@ -25,7 +25,6 @@
 <style>
   button {
     color: #444;
-    text-shadow: 0px 0px 4px rgb(38 111 78 / 50%);
     background: none;
 
     border-color: rgba(224, 224, 224);


### PR DESCRIPTION
This removes the weird shadow effect on text buttons for social buttons by removing `text-shadow`

## Current behavior

![CleanShot 2022-10-17 at 17 13 08](https://user-images.githubusercontent.com/13159333/196284828-a829050b-68e8-4f5a-98dc-e160ead9df9a.jpg)

## New behavior

![CleanShot 2022-10-17 at 17 12 57](https://user-images.githubusercontent.com/13159333/196284851-32f37e11-63ee-4df3-a430-cd557f33b6e4.jpg)

Please note that styles can be found in the official supabase docs [here](https://github.com/supabase/supabase/blob/f016160539a8cad99c9d9e257c91f3adb357e09b/packages/ui/src/components/Button/Button.module.css).