### PR TITLE
Optionally show magic link on sign-up page

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Default is `medium`.
 A `string` that specifies the layout direction of the social buttons. Valid options are `horizontal` or `vertical`.
 Default is `vertical`.
 
+## `magicLink`
+
+A `boolean` that specifies whether to show the magic link option on the sign-up page. 
+Default is `false`.
+
 ## `socialColors`
 
 A `boolean` that indicates whether the social buttons should use the brand's colors.

--- a/src/Auth.svelte
+++ b/src/Auth.svelte
@@ -14,6 +14,7 @@
   export let socialButtonSize = 'medium'
   export let providers = []
   export let view = 'sign_in'
+  export let magicLink = false;
 
   function setView(newView) {
     view = newView
@@ -32,7 +33,7 @@
     />
 
     {#if view == 'sign_in' || view == 'sign_up'}
-      <EmailAuthView {supabaseClient} {view} {setView}/>
+      <EmailAuthView {supabaseClient} {view} {setView} {magicLink}/>
     {:else if view == 'magic_link'}
       <MagicLinkView {supabaseClient} {setView}/>
     {:else if view == 'forgotten_password'}

--- a/src/EmailAuthView.svelte
+++ b/src/EmailAuthView.svelte
@@ -7,6 +7,7 @@
   export let supabaseClient
   export let view
   export let setView
+  export let magicLink;
 
   let error = '', message = '', loading = false, email = '', password = ''
 
@@ -40,7 +41,9 @@
   {#if view == 'sign_up'}
     <Button block primary size="large" {loading} icon="inbox">Sign up</Button>
     <div class="links">
-      <LinkButton on:click={() => setView('magic_link')}>Sign in with magic link</LinkButton>
+      {#if magicLink === true}
+        <LinkButton on:click={() => setView('magic_link')}>Sign in with magic link</LinkButton>
+      {/if}
       <LinkButton on:click={() => setView('sign_in')}>Do you have an account? Sign in</LinkButton>
     </div>
   {:else}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,6 +10,7 @@ export interface AuthProps {
   socialLayout?: 'vertical' | 'horizontal'
   socialColors?: boolean
   socialButtonSize?: 'medium' | 'large'
+  magicLink?: boolean
 }
 
 export default class Auth extends SvelteComponentTyped<AuthProps> {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

When you sign-up, it gives the user the option of signing in with a magic link.

## What is the new behavior?

You can set a boolean to not show a magic link if you don't want to support that login option.

## Additional context

Closes https://github.com/supabase-community/supabase-ui-svelte/issues/4
